### PR TITLE
Hide editors by default

### DIFF
--- a/lib/control.ex
+++ b/lib/control.ex
@@ -7,7 +7,7 @@ defmodule TestedCell.Control do
   use Agent
 
   def start_link(_opts) do
-    Agent.start_link(fn -> %{display_editors: true, max_attempts: 3} end, name: __MODULE__)
+    Agent.start_link(fn -> %{display_editors: false, max_attempts: 3} end, name: __MODULE__)
   end
 
   @doc """
@@ -30,16 +30,16 @@ defmodule TestedCell.Control do
   end
 
   @doc """
-  Hide text editors
+  Show text editors
 
   ## Examples
 
-    iex> TestedCell.Control.hide_editors()
+    iex> TestedCell.Control.show_editors()
     iex> TestedCell.Control.editors_enabled?()
-    false
+    true
   """
-  def hide_editors do
-    Agent.update(__MODULE__, fn state -> Map.put(state, :display_editors, false) end)
+  def show_editors do
+    Agent.update(__MODULE__, fn state -> Map.put(state, :display_editors, true) end)
   end
 
   @doc """

--- a/notebooks/example.livemd
+++ b/notebooks/example.livemd
@@ -17,7 +17,7 @@ The `TestedCell.Control` module configures the `TestedCell`. We can set whether 
 Disconnect and Reconnect the livebook in **Runtime Settings** or press the `00` keybinding to pick up these changes.
 
 ```elixir
-# TestedCell.Control.hide_editors()
+# TestedCell.Control.show_editors()
 ```
 
 ```elixir


### PR DESCRIPTION
I feel like it will be better to set `display_editors` as false by default.

We'll just need to add `TestedCell.Control.show_editors()` in the livebook we are currently editing instead of adding `TestedCell.Control.hide_editors()` in all finished livebook