### PR TITLE
Use git option in project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run tests on an Elixir Cell without revealing the tests or writing a significant
 Add the dependency in your Livebook setup section.
 
 ```elixir
-Mix.install([{:tested_cell, github: "https://github.com/BrooklinJazz/tested_cell"}])
+Mix.install([{:tested_cell, git: "https://github.com/BrooklinJazz/tested_cell"}])
 ```
 
 ## Usage


### PR DESCRIPTION
Using a github full link with the github option occurs an error:
![image](https://user-images.githubusercontent.com/34044731/181818219-5f8b8737-8fcb-4303-8a42-4fa46b1183c1.png)

We should use git option with github full link or github option with `username/repository` shortcut.